### PR TITLE
Exclude specific speakers from being listed in module

### DIFF
--- a/sonos.js
+++ b/sonos.js
@@ -31,20 +31,22 @@
 	render: function(data){
 		var text = '';
 		$.each(data, function (i, item) {
-			var room = item.coordinator.roomName;
-			var state = item.coordinator.state.zoneState;
-			var artist = item.coordinator.state.currentTrack.artist;
-			var track = item.coordinator.state.currentTrack.title;
-			var cover = item.coordinator.state.currentTrack.absoluteAlbumArtURI;
-			var streamInfo = item.coordinator.state.currentTrack.streamInfo;
-			if(item.members.length > 1){
-				room = '';
-				$.each(item.members, function (j, member) {
-					room += member.roomName + ', ';
-				});
-				room = room.slice(0, -2);
+			if(this.config.exclude.indexOf(item.coordinator.roomName) === -1){
+				var room = item.coordinator.roomName;
+				var state = item.coordinator.state.zoneState;
+				var artist = item.coordinator.state.currentTrack.artist;
+				var track = item.coordinator.state.currentTrack.title;
+				var cover = item.coordinator.state.currentTrack.absoluteAlbumArtURI;
+				var streamInfo = item.coordinator.state.currentTrack.streamInfo;
+				if(item.members.length > 1){
+					room = '';
+					$.each(item.members, function (j, member) {
+						room += member.roomName + ', ';
+					});
+					room = room.slice(0, -2);
+				}
+				text += this.renderRoom(state, artist, track, cover, room);
 			}
-			text += this.renderRoom(state, artist, track, cover, room);
 		}.bind(this));
 		this.loaded = true;
 		// only update dom if content changed


### PR DESCRIPTION
Adds functionality to exclude specific Sonos speakers from being listed in magic mirror module.

Use option 'exclude' in your config.js file to configure module.

example

```
        config: {
            showStoppedRoom: false,
            showAlbumArt: true,
            showRoomName: false,
            exclude: ['Living Room','Bedroom','Bathroom']
                }
```

Thanks to @STRAWBERRY 3.141 for writing the code
